### PR TITLE
feat: Add unit test for publishers and futures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Carthage/Build
 # `pod install` in .travis.yml
 #
 Example/Pods/
+
+gen/

--- a/Example/GoogleMapsPlatformCombine.xcodeproj/project.pbxproj
+++ b/Example/GoogleMapsPlatformCombine.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4092D1FC08605107222E1F23 /* Pods_GoogleMapsPlatformCombine_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA3881228F9785FE306E121E /* Pods_GoogleMapsPlatformCombine_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -27,7 +26,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2955CD2D61B4886360E37528 /* Pods-GoogleMapsPlatformCombine_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GoogleMapsPlatformCombine_Tests.debug.xcconfig"; path = "Target Support Files/Pods-GoogleMapsPlatformCombine_Tests/Pods-GoogleMapsPlatformCombine_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		2AEB59E91C42B9DB8E439749 /* GoogleMapsPlatformCombine.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = GoogleMapsPlatformCombine.podspec; path = ../GoogleMapsPlatformCombine.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		4DEEC26D5F027DCDE1E9F2EF /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* GoogleMapsPlatformCombine_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GoogleMapsPlatformCombine_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -41,9 +39,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A00626B40A6A57C00E37B85E /* Pods-GoogleMapsPlatformCombine_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GoogleMapsPlatformCombine_Example.release.xcconfig"; path = "Target Support Files/Pods-GoogleMapsPlatformCombine_Example/Pods-GoogleMapsPlatformCombine_Example.release.xcconfig"; sourceTree = "<group>"; };
 		AE488A8BF47F9F461FBCB248 /* Pods-GoogleMapsPlatformCombine_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GoogleMapsPlatformCombine_Example.debug.xcconfig"; path = "Target Support Files/Pods-GoogleMapsPlatformCombine_Example/Pods-GoogleMapsPlatformCombine_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		DA3881228F9785FE306E121E /* Pods_GoogleMapsPlatformCombine_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GoogleMapsPlatformCombine_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7F7ADF68EF51C78B5F8C778 /* Pods_GoogleMapsPlatformCombine_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GoogleMapsPlatformCombine_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E9BE129C70698AA813930D6C /* Pods-GoogleMapsPlatformCombine_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GoogleMapsPlatformCombine_Tests.release.xcconfig"; path = "Target Support Files/Pods-GoogleMapsPlatformCombine_Tests/Pods-GoogleMapsPlatformCombine_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		FD241D12DD14B1173D7596E4 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -60,7 +56,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4092D1FC08605107222E1F23 /* Pods_GoogleMapsPlatformCombine_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -72,8 +67,6 @@
 			children = (
 				AE488A8BF47F9F461FBCB248 /* Pods-GoogleMapsPlatformCombine_Example.debug.xcconfig */,
 				A00626B40A6A57C00E37B85E /* Pods-GoogleMapsPlatformCombine_Example.release.xcconfig */,
-				2955CD2D61B4886360E37528 /* Pods-GoogleMapsPlatformCombine_Tests.debug.xcconfig */,
-				E9BE129C70698AA813930D6C /* Pods-GoogleMapsPlatformCombine_Tests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -151,7 +144,6 @@
 			isa = PBXGroup;
 			children = (
 				E7F7ADF68EF51C78B5F8C778 /* Pods_GoogleMapsPlatformCombine_Example.framework */,
-				DA3881228F9785FE306E121E /* Pods_GoogleMapsPlatformCombine_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -182,7 +174,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "GoogleMapsPlatformCombine_Tests" */;
 			buildPhases = (
-				5805906A493390B81CA27BC9 /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
@@ -277,28 +268,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GoogleMapsPlatformCombine_Example/Pods-GoogleMapsPlatformCombine_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5805906A493390B81CA27BC9 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-GoogleMapsPlatformCombine_Tests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CDEB5D4EBC0F36D37D4128E0 /* [CP] Check Pods Manifest.lock */ = {
@@ -505,7 +474,6 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2955CD2D61B4886360E37528 /* Pods-GoogleMapsPlatformCombine_Tests.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
@@ -527,7 +495,6 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E9BE129C70698AA813930D6C /* Pods-GoogleMapsPlatformCombine_Tests.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",

--- a/Example/GoogleMapsPlatformCombine.xcodeproj/xcshareddata/xcschemes/GoogleMapsPlatformCombine-Example.xcscheme
+++ b/Example/GoogleMapsPlatformCombine.xcodeproj/xcshareddata/xcschemes/GoogleMapsPlatformCombine-Example.xcscheme
@@ -40,8 +40,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "GoogleMapsPlatformCombine_Example.app"
+            BlueprintName = "GoogleMapsPlatformCombine_Example"
+            ReferencedContainer = "container:GoogleMapsPlatformCombine.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,23 +62,11 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
-            BuildableName = "GoogleMapsPlatformCombine_Example.app"
-            BlueprintName = "GoogleMapsPlatformCombine_Example"
-            ReferencedContainer = "container:GoogleMapsPlatformCombine.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -87,8 +83,6 @@
             ReferencedContainer = "container:GoogleMapsPlatformCombine.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/GoogleMapsPlatformCombine/AppDelegate.swift
+++ b/Example/GoogleMapsPlatformCombine/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // TODO: Read API key from a version control hidden file
         GMSServices.provideAPIKey("YOUR_API_KEY")
         return true

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,13 +3,5 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'GoogleMapsPlatformCombine_Example' do
-  pod 'GoogleMapsPlatformCombine/Maps', :path => '../'
-  pod 'GoogleMapsPlatformCombine/Places', :path => '../'
-
-  target 'GoogleMapsPlatformCombine_Tests' do
-    inherit! :search_paths
-
-    # pod 'Quick', '~> 2.2.0'
-    # pod 'Nimble', '~> 8.0.7'
-  end
+  pod 'GoogleMapsPlatformCombine', :path => '../', :testspecs => ['Tests']
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,20 +4,27 @@ PODS:
   - GoogleMaps/Base (5.1.0)
   - GoogleMaps/Maps (5.1.0):
     - GoogleMaps/Base
+  - GoogleMapsPlatformCombine (0.1.0):
+    - GoogleMapsPlatformCombine/Maps (= 0.1.0)
+    - GoogleMapsPlatformCombine/Places (= 0.1.0)
   - GoogleMapsPlatformCombine/Maps (0.1.0):
     - GoogleMaps (= 5.1.0)
   - GoogleMapsPlatformCombine/Places (0.1.0):
     - GooglePlaces (= 5.0.0)
+  - GoogleMapsPlatformCombine/Tests (0.1.0):
+    - OCMock
   - GooglePlaces (5.0.0)
+  - OCMock (3.8.1)
 
 DEPENDENCIES:
-  - GoogleMapsPlatformCombine/Maps (from `../`)
-  - GoogleMapsPlatformCombine/Places (from `../`)
+  - GoogleMapsPlatformCombine (from `../`)
+  - GoogleMapsPlatformCombine/Tests (from `../`)
 
 SPEC REPOS:
   trunk:
     - GoogleMaps
     - GooglePlaces
+    - OCMock
 
 EXTERNAL SOURCES:
   GoogleMapsPlatformCombine:
@@ -25,9 +32,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   GoogleMaps: 086ae1dab659eaa7339bdb30fc88e2f44e7c597c
-  GoogleMapsPlatformCombine: 74c23ccf85ab84fe5c2b30ba0b722a1e38c4faba
+  GoogleMapsPlatformCombine: 6f0c6dda750185bfd44aa98ac7f6706e56747d09
   GooglePlaces: 5d87ca13ed98b7a937e0d8bc7026f718c7263271
+  OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
 
-PODFILE CHECKSUM: f34952039b4867ac9d11bb9616e96d35035b81bf
+PODFILE CHECKSUM: f11b1fc695da1f97d428fc382a40d8b2ce0382cb
 
 COCOAPODS: 1.9.1

--- a/GoogleMapsPlatformCombine.podspec
+++ b/GoogleMapsPlatformCombine.podspec
@@ -30,5 +30,10 @@ A swift library that provides Combine support via Publisher and Future for Googl
     ss.dependency 'GooglePlaces', '5.0.0'
   end
 
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = "Tests/Unit/**/*.swift"
+    test_spec.dependency 'OCMock'
+  end
+
   s.static_framework = true
 end

--- a/Sources/Places/GMSPlacesClient+Combine.swift
+++ b/Sources/Places/GMSPlacesClient+Combine.swift
@@ -144,7 +144,7 @@ extension GMSPlacesClient {
     ///
     /// - Parameter fields: the individual place fields requested for the place objects in the list
     /// - Returns: a publisher returning a list of likely places the user is at
-    public func findPlaceLikelihoodsFromCurrentPlace(
+    public func findPlaceLikelihoodsFromCurrentLocation(
         fields: GMSPlaceField
     ) -> Future<[GMSPlaceLikelihood], Error> {
         Future<[GMSPlaceLikelihood], Error> { promise in

--- a/Tests/Unit/GMSMapViewPublisherTests.swift
+++ b/Tests/Unit/GMSMapViewPublisherTests.swift
@@ -1,0 +1,289 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleMaps
+import OCMock
+import XCTest
+
+@testable import GoogleMapsPlatformCombine
+
+class GmsMapViewPublisherTests : XCTestCase {
+
+    private let expectationTimeout: TimeInterval = 1
+
+    private var mapView: GMSMapView!
+    private var publisher: GMSMapViewPublisher!
+
+    /// Class to allow instantiation of a GMSOverlay type
+    class MockOverlay: GMSOverlay {
+    }
+
+    override func setUp() {
+        super.setUp()
+        GMSServices.provideAPIKey("Test")
+        mapView = GMSMapView()
+        publisher = GMSMapViewPublisher(mapView: mapView)
+    }
+
+    func testPublisherEmitsWillMove() {
+        let expect  = expectation(description: "Publisher emits on willMove")
+        let cancellable = publisher.willMove.sink { _ in
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, willMove: true)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidChangeCameraPosition() {
+        let expect  = expectation(description: "Publisher emits on didChangeCameraPosition")
+        let position = GMSCameraPosition(latitude: 0, longitude: 0, zoom: 0)
+        let cancellable = publisher.didChangeCameraPosition.sink { newPosition in
+            XCTAssertEqual(position, newPosition)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didChange: position)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsidleAtCameraPosition() {
+        let expect  = expectation(description: "Publisher emits on idleAtCameraPosition")
+        let position = GMSCameraPosition(latitude: 0, longitude: 0, zoom: 0)
+        let cancellable = publisher.idleAtCameraPosition.sink { newPosition in
+            XCTAssertEqual(position, newPosition)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, idleAt: position)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidTapAtCoordinate() {
+        let expect  = expectation(description: "Publisher emits on didTapAtCoordinate")
+        let coordinate = CLLocationCoordinate2DMake(0, 0)
+        let cancellable = publisher.didTapAtCoordinate.sink { tappedCoordinate in
+            XCTAssertEqual(coordinate.latitude, tappedCoordinate.latitude)
+            XCTAssertEqual(coordinate.longitude, tappedCoordinate.longitude)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didTapAt: coordinate)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidLongPressAtCoordinate() {
+        let expect  = expectation(description: "Publisher emits on didLongPressAtCoordinate")
+        let coordinate = CLLocationCoordinate2DMake(0, 0)
+        let cancellable = publisher.didLongPressAtCoordinate.sink { tappedCoordinate in
+            XCTAssertEqual(coordinate.latitude, tappedCoordinate.latitude)
+            XCTAssertEqual(coordinate.longitude, tappedCoordinate.longitude)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didLongPressAt: coordinate)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidTapMarker() {
+        let expect  = expectation(description: "Publisher emits on didTapMarker")
+        let marker = GMSMarker(position: CLLocationCoordinate2D(latitude: 0, longitude: 0))
+        let cancellable = publisher.didTapMarker().sink { tappedMarker in
+            XCTAssertEqual(marker, tappedMarker)
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapView?(mapView, didTap: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidTapInfoWindow() {
+        let expect  = expectation(description: "Publisher emits on didTapInfoWindow")
+        let marker = GMSMarker(position: CLLocationCoordinate2D(latitude: 0, longitude: 0))
+        let cancellable = publisher.didTapInfoWindow.sink { tappedMarker in
+            XCTAssertEqual(marker, tappedMarker)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didTapInfoWindowOf: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidLongPressInfoWindowOf() {
+        let expect  = expectation(description: "Publisher emits on didLongPressInfoWindowOf")
+        let marker = GMSMarker(position: CLLocationCoordinate2D(latitude: 0, longitude: 0))
+        let cancellable = publisher.didLongPressInfoWindow.sink { tappedMarker in
+            XCTAssertEqual(marker, tappedMarker)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didLongPressInfoWindowOf: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidTapOverlay() {
+        let expect  = expectation(description: "Publisher emits on didTapOverlay")
+        let overlay = MockOverlay()
+        let cancellable = publisher.didTapOverlay.sink { tappedOverlay in
+            XCTAssertEqual(overlay, tappedOverlay)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didTap: overlay)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidTapPOI() {
+        let expect  = expectation(description: "Publisher emits on didTapPOI")
+        let placeId = "placeId"
+        let name = "place name"
+        let location = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let cancellable = publisher.didTapPOI.sink { (rplaceId, rname, rlocation) in
+            XCTAssertEqual(placeId, rplaceId)
+            XCTAssertEqual(name, rname)
+            XCTAssertEqual(location.latitude, rlocation.latitude)
+            XCTAssertEqual(location.longitude, rlocation.longitude)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didTapPOIWithPlaceID: placeId, name: name, location: location)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsMarkerInfoWindow() {
+        let expect  = expectation(description: "Publisher emits on markerInfoWindow")
+        let marker = GMSMarker()
+        let cancellable = publisher.markerInfoWindow().sink { m in
+            XCTAssertEqual(marker, m)
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapView?(mapView, markerInfoWindow: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsMarkerInfoContents() {
+        let expect  = expectation(description: "Publisher emits on markerInfoContents")
+        let marker = GMSMarker()
+        let cancellable = publisher.markerInfoContents().sink { m in
+            XCTAssertEqual(marker, m)
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapView?(mapView, markerInfoContents: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidCloseInfoWindowOf() {
+        let expect  = expectation(description: "Publisher emits on didCloseInfoWindowOf")
+        let marker = GMSMarker()
+        let cancellable = publisher.didCloseInfoWindowOf.sink { m in
+            XCTAssertEqual(marker, m)
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapView?(mapView, didCloseInfoWindowOf: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidBeginDragging() {
+        let expect  = expectation(description: "Publisher emits on didBeginDragging")
+        let marker = GMSMarker()
+        let cancellable = publisher.didBeginDragging.sink { m in
+            XCTAssertEqual(marker, m)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didBeginDragging: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidEndDragging() {
+        let expect  = expectation(description: "Publisher emits on didEndDragging")
+        let marker = GMSMarker()
+        let cancellable = publisher.didEndDragging.sink { m in
+            XCTAssertEqual(marker, m)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didEndDragging: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidDrag() {
+        let expect  = expectation(description: "Publisher emits on didDrag")
+        let marker = GMSMarker()
+        let cancellable = publisher.didDrag.sink { m in
+            XCTAssertEqual(marker, m)
+            expect.fulfill()
+        }
+        mapView.delegate?.mapView?(mapView, didDrag: marker)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidTapMyLocationButton() {
+        let expect  = expectation(description: "Publisher emits on didTapMyLocationButton")
+        let cancellable = publisher.didTapMyLocationButton().sink { _ in
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.didTapMyLocationButton?(for: mapView)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidTapMyLocation() {
+        let expect  = expectation(description: "Publisher emits on didTapMyLocation")
+        let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let cancellable = publisher.didTapMyLocation.sink { coord in
+            XCTAssertEqual(coordinate.latitude, coord.latitude)
+            XCTAssertEqual(coordinate.longitude, coord.longitude)
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapView?(mapView, didTapMyLocation: coordinate)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidStartTileRendering() {
+        let expect  = expectation(description: "Publisher emits on didStartTileRendering")
+        let cancellable = publisher.didStartTileRendering.sink {
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapViewDidStartTileRendering?(mapView)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsDidFinishTileRendering() {
+        let expect  = expectation(description: "Publisher emits on didFinishTileRendering")
+        let cancellable = publisher.didFinishTileRendering.sink {
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapViewDidFinishTileRendering?(mapView)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+
+    func testPublisherEmitsSnapshotReady() {
+        let expect  = expectation(description: "Publisher emits on snapshotReady")
+        let cancellable = publisher.snapshotReady.sink {
+            expect.fulfill()
+        }
+        _ = mapView.delegate?.mapViewSnapshotReady?(mapView)
+        wait(for: [expect], timeout: expectationTimeout)
+        cancellable.cancel()
+    }
+}

--- a/Tests/Unit/GMSPlacesClientCombineTests.swift
+++ b/Tests/Unit/GMSPlacesClientCombineTests.swift
@@ -1,0 +1,122 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+//  GMSPlacesClientCombineTests.swift
+//  GoogleMapsPlatformCombine-Unit-Tests
+//
+//  Created by Chris Arriola on 11/11/21.
+//
+
+import Combine
+import Foundation
+import GooglePlaces
+import XCTest
+
+class GMSPlacesClientCombineTests : XCTestCase {
+
+    private let expectationTimeout: TimeInterval = 1
+    var client: PlacesClientFake!
+
+    override func setUp() {
+        super.setUp()
+        client = PlacesClientFake()
+    }
+
+    func testFindAutocompletePredictionsSuccess() {
+        let response: ([GMSAutocompletePrediction], NSError?) = ([], nil)
+        client.mockFindAutocompletePredictions = response
+
+        let expect = expectation(description: #function)
+        var cancellables: [AnyCancellable] = []
+        client.findAutocompletePredictions(from: "query").sink { completion in
+            switch completion {
+            case .finished:
+                expect.fulfill()
+            case .failure(_):
+                XCTFail("Error should not have occured.")
+            }
+
+        } receiveValue: { predictions in
+            XCTAssertEqual(response.0, predictions)
+        }
+        .store(in: &cancellables)
+        wait(for: [expect], timeout: expectationTimeout)
+    }
+
+    func testFindAutocompletePredictionFailure() {
+        let response: ([GMSAutocompletePrediction]?, NSError) = (nil, NSError(domain: "", code: 1, userInfo: nil))
+        client.mockFindAutocompletePredictions = response
+
+        let expect = expectation(description: #function)
+        var cancellables: [AnyCancellable] = []
+        client.findAutocompletePredictions(from: "query").sink { completion in
+            switch completion {
+            case .finished:
+                XCTFail("Error should have occured.")
+            case let .failure(error as NSError):
+                XCTAssertEqual(response.1.code, error.code)
+                expect.fulfill()
+            }
+
+        } receiveValue: { predictions in
+            XCTFail("Error should have occured.")
+        }
+        .store(in: &cancellables)
+        wait(for: [expect], timeout: expectationTimeout)
+    }
+
+    func testfindPlaceLikelihoodsFromCurrentLocationSuccess() {
+        let response: ([GMSPlaceLikelihood], NSError?) = ([], nil)
+        client.mockFindPlaceLikelihoodsFromCurrentLocation = response
+
+        let expect = expectation(description: #function)
+        var cancellables: [AnyCancellable] = []
+        client.findPlaceLikelihoodsFromCurrentLocation(fields: .name).sink { completion in
+            switch completion {
+            case .finished:
+                expect.fulfill()
+            case .failure(_):
+                XCTFail("Error should not have occured.")
+            }
+
+        } receiveValue: { predictions in
+            XCTAssertEqual(response.0, predictions)
+        }
+        .store(in: &cancellables)
+        wait(for: [expect], timeout: expectationTimeout)
+    }
+
+    func testfindPlaceLikelihoodsFromCurrentLocationFailure() {
+        let response: ([GMSPlaceLikelihood]?, NSError) = (nil, NSError(domain: "", code: 1, userInfo: nil))
+        client.mockFindPlaceLikelihoodsFromCurrentLocation = response
+
+        let expect = expectation(description: #function)
+        var cancellables: [AnyCancellable] = []
+        client.findPlaceLikelihoodsFromCurrentLocation(fields: .name).sink { completion in
+            switch completion {
+            case .finished:
+                XCTFail("Error should have occured.")
+            case let .failure(error as NSError):
+                XCTAssertEqual(response.1.code, error.code)
+                expect.fulfill()
+            }
+
+        } receiveValue: { predictions in
+            XCTFail("Error should have occured.")
+        }
+        .store(in: &cancellables)
+        wait(for: [expect], timeout: expectationTimeout)
+    }
+}

--- a/Tests/Unit/PlacesClientFake.swift
+++ b/Tests/Unit/PlacesClientFake.swift
@@ -1,0 +1,46 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+//  PlacesClientFake.swift
+//  GoogleMapsPlatformCombine-Unit-Tests
+//
+//  Created by Chris Arriola on 11/11/21.
+//
+
+import Combine
+import Foundation
+import GooglePlaces
+
+class PlacesClientFake : GMSPlacesClient {
+
+    var mockFindAutocompletePredictions: ([GMSAutocompletePrediction]?, Error?)?
+    var mockFindPlaceLikelihoodsFromCurrentLocation: ([GMSPlaceLikelihood]?, Error?)?
+
+    override func findAutocompletePredictions(fromQuery query: String, filter: GMSAutocompleteFilter?, sessionToken: GMSAutocompleteSessionToken?, callback: @escaping GMSAutocompletePredictionsCallback) {
+        guard let response = mockFindAutocompletePredictions else {
+            callback(nil, nil)
+            return
+        }
+        callback(response.0, response.1)
+    }
+
+    override func findPlaceLikelihoodsFromCurrentLocation(withPlaceFields placeFields: GMSPlaceField, callback: @escaping GMSPlaceLikelihoodsCallback) {
+        guard let response = mockFindPlaceLikelihoodsFromCurrentLocation else {
+            callback(nil, nil)
+            return
+        }
+        callback(response.0, response.1)
+    }
+}


### PR DESCRIPTION
* Adds unit tests for all extensions
* This also updates the method name from `findPlaceLikelihoodsFromCurrentPlace`
to `findPlaceLikelihoodsFromCurrentLocation` to match the underlying
method name.